### PR TITLE
custom middleware can be assigned to a specific path

### DIFF
--- a/src/middleware/express.app.config.ts
+++ b/src/middleware/express.app.config.ts
@@ -49,7 +49,7 @@ export class ExpressAppConfig {
         this.app.use(OpenApiValidator.middleware(this.openApiValidatorOptions));
         this.app.use(new SwaggerParameters().checkParameters());
         // Bind custom middlewares which need access to the OpenApiRequest context before controllers initialization
-        (customMiddlewares || []).forEach(middleware => this.app.use(middleware))
+        (customMiddlewares || []).forEach(middleware => this.app.use(...middleware))
         this.app.use(new SwaggerRouter().initialize(this.routingOptions));
 
         this.app.use(this.errorHandler);


### PR DESCRIPTION
## Summary
pass multiple arguments to this.app.use in custom middlewares

### Proposed changes
convert customMiddlewares variable to an array.

Is there another way to pass middlewares for specific path? what if I want to use app.get instead of app.use?

changes in index.js:
```
var expressAppConfig = oas3Tools.expressAppConfig(path.join(__dirname, 'api/openapi.yaml'), options, [["/custom/path/", middleware]]);
var app = expressAppConfig.getApp();
```
